### PR TITLE
Extracting logic to build business summary + cross building

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ The purpose of this project is to provide core elements for other business regis
 
 Project can be built using either `sbt` installed locally or `bin/sbt` script. First approach will be used in all examples presented here.
 
+NOTE: Scala 2.11 is used by default but project can be cross built for Scala 2.10 as well. For more information please read [SBT documentation](http://www.scala-sbt.org/1.0/docs/Cross-Build.html).  
+
 ## How to build it
 
 To build the project please execute following command:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To build the project please execute following command:
 sbt package
 ```
 
-Above command will create `business-core_2.10-1.0.0-SNAPSHOT.jar` JAR file in `target/scala-2.10` directory.
+Above command will create `business-core_2.11-1.0.0-SNAPSHOT.jar` JAR file in `target/scala-2.11` directory.
 
 ## How to publish package to local repository
 
@@ -24,7 +24,7 @@ To publish package to local repository please execute following command:
 sbt publishLocal
 ```
 
-Above command will copy descriptor and artifacts to `~/.ivy2/local/uk.gov.ons.business-register/business-core_2.10/1.0.0-SNAPSHOT` directory so that other projects can specify this project as a dependency.
+Above command will copy descriptor and artifacts to `~/.ivy2/local/uk.gov.ons.business-register/business-core_2.11/1.0.0-SNAPSHOT` directory so that other projects can specify this project as a dependency.
 
 ## How to use it as a dependency in other projects
 
@@ -39,7 +39,7 @@ To use this project as a dependency in other Maven projects please add following
 ```
 <dependency>
   <groupId>uk.gov.ons.business-register</groupId>
-  <artifactId>business-core_2.10</artifactId>
+  <artifactId>business-core_2.11</artifactId>
   <version>1.0.0-SNAPSHOT</version>
 </dependency>
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,8 @@ lazy val artifactSettings = Seq(
 )
 
 lazy val buildSettings = Seq(
-  scalaVersion := "2.10.6",
+  scalaVersion := "2.11.8",
+  crossScalaVersions := Seq("2.10.6", "2.11.8"),
   // Scala / Java options
   scalacOptions ++= Seq("-deprecation", "-unchecked"),
   javacOptions ++= Seq("-source", "1.7", "-target", "1.7"),

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ lazy val buildSettings = Seq(
 // Modules
 
 val sparkVersion = "1.6.2"
-val sparkDependencyScope = "compile"
+val sparkDependencyScope = "provided"
 
 val root = Project("business-core", file("."))
   .settings(artifactSettings: _*)

--- a/src/main/scala/uk/gov/ons/business/csv/BusinessFieldsRetriever.scala
+++ b/src/main/scala/uk/gov/ons/business/csv/BusinessFieldsRetriever.scala
@@ -1,0 +1,85 @@
+package uk.gov.ons.business.csv
+
+import uk.gov.ons.business.csv.{DataRecordField => Field}
+import uk.gov.ons.business.model.DataSourceTypes._
+import uk.gov.ons.business.model.{BusinessIndexRecord, DataRecord}
+
+class BusinessFieldsRetriever(fieldRetriever: FieldRetriever) extends Serializable {
+
+  @transient
+  private lazy val businessFields = List(
+    Field.CompanyName,
+    Field.Postcode,
+    Field.IndustryCode,
+    Field.LegalStatus,
+    Field.TradingStatus,
+    Field.Turnover,
+    Field.TotalEmployees
+  )
+
+  @transient
+  private lazy val sources = Map(
+    Field.CompanyName -> List(companiesHouse, vat, charityCommission, paye),
+    Field.Postcode -> List(companiesHouse, charityCommission, vat, paye),
+    Field.IndustryCode -> List(vat, companiesHouse, paye),
+    Field.LegalStatus -> List(companiesHouse, vat, paye),
+    Field.TradingStatus -> List(companiesHouse, vat, paye),
+    Field.Turnover -> List(vat),
+    Field.TotalEmployees -> List(paye)
+  )
+
+  def getEmptyFields: List[String] = {
+    List.fill(businessFields.length)("")
+  }
+
+  def getFieldsForBusinessIndex(businessIndexRecord: BusinessIndexRecord): List[String] = {
+    val getField = getBusinessField(businessIndexRecord) _
+
+    businessFields.map(getField)
+  }
+
+  private def getBusinessField(businessIndexRecord: BusinessIndexRecord)(dataRecordField: Field.Value) = {
+    fieldRetriever.getField(businessIndexRecord, dataRecordField, sources(dataRecordField))
+  }
+
+  def getFieldsForDataRecord(dataRecord: DataRecord): List[String] = {
+    val getField = getBusinessField(dataRecord) _
+
+    businessFields.map(getField)
+  }
+
+  private def getBusinessField(dataRecord: DataRecord)(dataRecordField: Field.Value) = {
+    fieldRetriever.getField(dataRecord, dataRecordField)
+  }
+
+}
+
+class FieldRetriever extends Serializable {
+  def getField(businessIndexRecord: BusinessIndexRecord, field: DataRecordField.Value, sourcesByPriority: List[String]) = {
+    val fieldInSources = sourcesByPriority.iterator.flatMap { source =>
+      businessIndexRecord.sourceRecords.get(source).flatMap(record => getFieldValue(record, field))
+    }.toIterable
+
+    fieldInSources.headOption.getOrElse("")
+  }
+
+  def getField(dataRecord: DataRecord, field: DataRecordField.Value) = getFieldValue(dataRecord, field).getOrElse("")
+
+  private def getFieldValue(dataRecord: DataRecord, field: DataRecordField.Value): Option[String] = {
+    field match {
+      case Field.CompanyName => Some(dataRecord.companyName)
+      case Field.Postcode => dataRecord.postcode
+      case Field.IndustryCode => dataRecord.industryCode.map(_.toString)
+      case Field.LegalStatus => dataRecord.legalStatus
+      case Field.TradingStatus => dataRecord.tradingStatus
+      case Field.Turnover => dataRecord.turnover.map(_.toString)
+      case Field.TotalEmployees => dataRecord.totalEmployees.map(_.toString)
+    }
+  }
+}
+
+object DataRecordField extends Enumeration {
+  type DataRecordField = Value
+  val CompanyName, Postcode, IndustryCode, LegalStatus, TradingStatus, Turnover, TotalEmployees = Value
+}
+

--- a/src/main/scala/uk/gov/ons/business/model/DataRecord.scala
+++ b/src/main/scala/uk/gov/ons/business/model/DataRecord.scala
@@ -12,7 +12,7 @@ case class DataRecord(dataSource: String,
                       address: Option[String],
                       postcode: Option[String],
                       totalEmployees: Option[Int] = None,
-                      additionalData: Map[String, String],
+                      additionalData: Map[String, String] = Map(),
                       matchScore: Option[Double] = None,
                       // TODO: this field is populated for VAT only. Populate for other sources.
                       sourceSpecificId: Option[String] = None)

--- a/src/main/scala/uk/gov/ons/business/model/DataSourceTypes.scala
+++ b/src/main/scala/uk/gov/ons/business/model/DataSourceTypes.scala
@@ -1,0 +1,11 @@
+package uk.gov.ons.business.model
+
+object DataSourceTypes {
+  val businessIndex = "BusinessIndex"
+  val charityCommission = "CharityCommission"
+  val companiesHouse = "CompaniesHouse"
+  val vat = "Vat"
+  val paye = "Paye"
+
+  val all = List(companiesHouse, charityCommission, vat, paye)
+}

--- a/src/test/scala/uk/gov/ons/business/csv/FieldRetrieverTest.scala
+++ b/src/test/scala/uk/gov/ons/business/csv/FieldRetrieverTest.scala
@@ -1,0 +1,165 @@
+package uk.gov.ons.business.csv
+
+import org.scalatest.{FunSuite, Matchers}
+import uk.gov.ons.business.model.{BusinessIndexRecord, DataRecord}
+
+class FieldRetrieverTest extends FunSuite with Matchers {
+
+  val charityCommission = "CharityCommission"
+  val companiesHouse = "CompaniesHouse"
+  val hmrcVisionVat = "HMRCVisionVat"
+  val quarterlyPaye = "QuarterlyPaye"
+
+  val fieldRetriever = new FieldRetriever()
+
+  test("getField(BusinessIndexRecord) returns the right data field from the source") {
+    val companiesRecord = getSampleDataRecord(dataSource = companiesHouse)
+    val sourcesRecords: Map[String, DataRecord] = Map(
+      companiesHouse -> companiesRecord
+    )
+    val businessIndexRecord = getSampleBusinessRecord(sourceRecords = sourcesRecords)
+
+    val companyName = fieldRetriever.getField(businessIndexRecord, DataRecordField.CompanyName, List(companiesHouse))
+    val postcode = fieldRetriever.getField(businessIndexRecord, DataRecordField.Postcode, List(companiesHouse))
+    val industryCode = fieldRetriever.getField(businessIndexRecord, DataRecordField.IndustryCode, List(companiesHouse))
+    val legalStatus = fieldRetriever.getField(businessIndexRecord, DataRecordField.LegalStatus, List(companiesHouse))
+    val tradingStatus = fieldRetriever.getField(businessIndexRecord, DataRecordField.TradingStatus, List(companiesHouse))
+    val turnover = fieldRetriever.getField(businessIndexRecord, DataRecordField.Turnover, List(companiesHouse))
+    val totalEmployees = fieldRetriever.getField(businessIndexRecord, DataRecordField.TotalEmployees, List(companiesHouse))
+
+    companyName should be(companiesRecord.companyName)
+    postcode should be(companiesRecord.postcode.get)
+    industryCode should be(companiesRecord.industryCode.get.toString)
+    legalStatus should be(companiesRecord.legalStatus.get)
+    tradingStatus should be(companiesRecord.tradingStatus.get)
+    turnover should be(companiesRecord.turnover.map(_.toString()).get)
+    totalEmployees should be(companiesRecord.totalEmployees.map(_.toString()).get)
+  }
+
+  test("getField(BusinessIndexRecord) returns an empty string when none of the given sources are present in record") {
+    val prioritySources = List(companiesHouse, charityCommission, hmrcVisionVat)
+
+    val sourcesRecords: Map[String, DataRecord] = Map(
+      quarterlyPaye -> getSampleDataRecord(dataSource = quarterlyPaye, tradingStatus = Some("90009"))
+    )
+    val businessIndexRecord = getSampleBusinessRecord(sourceRecords = sourcesRecords)
+
+    val tradingStatus = fieldRetriever.getField(businessIndexRecord, DataRecordField.TradingStatus, prioritySources)
+    tradingStatus should be ("")
+  }
+
+  test("getField(BusinessIndexRecord) returns an empty string when the field is empty in each of the relevant sources") {
+    val prioritySources = List(companiesHouse, quarterlyPaye, hmrcVisionVat)
+
+    val companiesRecord = getSampleDataRecord(dataSource = companiesHouse, industryCode = None)
+    val payeRecord = getSampleDataRecord(dataSource = quarterlyPaye, industryCode = None)
+    val vatRecord = getSampleDataRecord(dataSource = hmrcVisionVat, industryCode = None)
+
+    val sourceRecords: Map[String, DataRecord] = Map(
+      companiesHouse -> companiesRecord,
+      quarterlyPaye -> payeRecord,
+      hmrcVisionVat -> vatRecord
+    )
+    val businessIndexRecord = getSampleBusinessRecord(sourceRecords = sourceRecords)
+
+    val industryCode = fieldRetriever.getField(businessIndexRecord, DataRecordField.IndustryCode, prioritySources)
+    industryCode should be ("")
+  }
+
+  test("getField(BusinessIndexRecord) returns the first present value based on the priority list") {
+    val firstPriorityList = List(companiesHouse, charityCommission, hmrcVisionVat)
+    val secondPriorityList =  List(companiesHouse, hmrcVisionVat, charityCommission)
+
+    val companiesRecord = getSampleDataRecord(dataSource = companiesHouse, industryCode = None)
+    val charityRecord = getSampleDataRecord(dataSource = charityCommission, industryCode = Some(90001))
+    val vatRecord = getSampleDataRecord(dataSource = hmrcVisionVat, industryCode = Some(90008))
+
+    val dataSources: Map[String, DataRecord] = Map(
+      companiesHouse -> companiesRecord,
+      charityCommission -> charityRecord,
+      hmrcVisionVat -> vatRecord
+    )
+    val businessIndexRecord = getSampleBusinessRecord(sourceRecords = dataSources)
+
+    val charityIndustryCode = fieldRetriever.getField(businessIndexRecord, DataRecordField.IndustryCode, firstPriorityList)
+    charityIndustryCode should be ("90001")
+
+    val vatIndustryCode = fieldRetriever.getField(businessIndexRecord, DataRecordField.IndustryCode, secondPriorityList)
+    vatIndustryCode should be ("90008")
+  }
+
+  test("getField(DataRecord) returns the given field from the given record") {
+    val sampleDataRecord = getSampleDataRecord()
+
+    val companyName = fieldRetriever.getField(sampleDataRecord, DataRecordField.CompanyName)
+    val postcode = fieldRetriever.getField(sampleDataRecord, DataRecordField.Postcode)
+    val industryCode = fieldRetriever.getField(sampleDataRecord, DataRecordField.IndustryCode)
+    val tradingStatus = fieldRetriever.getField(sampleDataRecord, DataRecordField.TradingStatus)
+    val legalStatus = fieldRetriever.getField(sampleDataRecord, DataRecordField.LegalStatus)
+    val turnover = fieldRetriever.getField(sampleDataRecord, DataRecordField.Turnover)
+    val totalEmployees = fieldRetriever.getField(sampleDataRecord, DataRecordField.TotalEmployees)
+
+    companyName should be(sampleDataRecord.companyName)
+    postcode should be(sampleDataRecord.postcode.get)
+    industryCode should be(sampleDataRecord.industryCode.get.toString)
+    legalStatus should be(sampleDataRecord.legalStatus.get)
+    tradingStatus should be(sampleDataRecord.tradingStatus.get)
+    turnover should be(sampleDataRecord.turnover.map(_.toString()).get)
+    totalEmployees should be(sampleDataRecord.totalEmployees.map(_.toString()).get)
+  }
+
+  test("getField(DataRecord) returns an empty string when the given field is absent") {
+    val dataRecord: DataRecord = getSampleDataRecord(companyName = null, tradingStatus = None, postcode = None,
+      turnover = None, legalStatus = None, totalEmployees = None, industryCode = None)
+
+    val companyName = fieldRetriever.getField(dataRecord, DataRecordField.CompanyName)
+    val postcode = fieldRetriever.getField(dataRecord, DataRecordField.Postcode)
+    val tradingStatus = fieldRetriever.getField(dataRecord, DataRecordField.TradingStatus)
+    val turnover = fieldRetriever.getField(dataRecord, DataRecordField.Turnover)
+    val legalStatus = fieldRetriever.getField(dataRecord, DataRecordField.LegalStatus)
+    val totalEmployees = fieldRetriever.getField(dataRecord, DataRecordField.TotalEmployees)
+    val industryCode = fieldRetriever.getField(dataRecord, DataRecordField.IndustryCode)
+
+    postcode should be ("")
+    tradingStatus should be ("")
+    turnover should be ("")
+    legalStatus should be ("")
+    totalEmployees should be ("")
+    industryCode should be ("")
+  }
+
+  private def getSampleBusinessRecord(businessId: String = "190093",
+                              sourceRecords: Map[String, DataRecord]) = {
+
+    BusinessIndexRecord(
+      id = businessId,
+      matchKey = "COMPANYNAME",
+      sourceRecords = sourceRecords
+    )
+  }
+
+  private def getSampleDataRecord(dataSource: String = "CompaniesHouse",
+                          companyName: String = "COMPANY NAME",
+                          industryCode: Option[Int] = Some(90000),
+                          tradingStatus: Option[String] = Some("INSOLVENT"),
+                          legalStatus: Option[String] = Some("1"),
+                          turnover: Option[Int] = Some(100000),
+                          totalEmployees: Option[Int] = Some(1000),
+                          postcode: Option[String] = Some("BT45 4TY")) = {
+
+    DataRecord(
+      dataSource = dataSource,
+      recordDigest = "dc3bebea9bf2cce",
+      companyName = companyName,
+      address = Some("74, STONE LANE"),
+      postcode = postcode,
+      turnover = turnover,
+      industryCode = industryCode,
+      legalStatus = legalStatus,
+      tradingStatus = tradingStatus,
+      totalEmployees = totalEmployees,
+      additionalData = Map(
+      )
+    )
+  }
+}


### PR DESCRIPTION
Main point od the pull request are:
- moving logic used to get business summary record so it can be reused
- making module available for both Scala 2.10 and Scala 2.11 (cross build)
- making spark dependencies 'provided' so other projects have to declare them explicitly
